### PR TITLE
Implemented code completion for formal specification

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -99,10 +99,10 @@ public class Scanner implements TerminalTokens {
 
 	//all javadoc comments
 	private final static int JAVADOC_COMMENT_ARRAYS_SIZE = 30;
-	private int[] javadocCommentStops = new int[JAVADOC_COMMENT_ARRAYS_SIZE];
-	private int[] javadocCommentStarts = new int[JAVADOC_COMMENT_ARRAYS_SIZE];
-	private int javadocCommentPtr = -1;
-	private int endOfLastJavadocComment = 0;
+	protected int[] javadocCommentStops = new int[JAVADOC_COMMENT_ARRAYS_SIZE];
+	protected int[] javadocCommentStarts = new int[JAVADOC_COMMENT_ARRAYS_SIZE];
+	protected int javadocCommentPtr = -1;
+	protected int endOfLastJavadocComment = 0;
 
 	public static class JavadocCommentsInfo {
 		int sourceLength;
@@ -2338,7 +2338,7 @@ protected int scanForTextBlock() throws InvalidInputException {
 public int javadocFormalPartTagStart;
 public int javadocFormalPartTagEnd;
 public FormalSpecificationClause.Tag javadocFormalPartTag;
-private int skipToNextJavadocFormalLine(boolean insideFormalPart) {
+protected int skipToNextJavadocFormalLine(boolean insideFormalPart) {
 	char[] src = this.source;
 	String lastTagSeen = null;
 


### PR DESCRIPTION
This pull request implements code completion on request of the user by pressing _Ctrl+Space_ in formal specification parts.

The adapted code in _CompletionScanner.getNextToken0()_, with exception of line 179 to 184, is code that was copied from _Scanner.getNextToken0()_ where recognition of formal specification tokens was already implemented earlier for FSC4J. By adding the code to the _CompletionScanner_, formal specification will now also be recognized while requesting code completion.